### PR TITLE
Add gpu dockerfile with fcl+octomap installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -131,8 +131,6 @@ RUN cd /fcl/build && make install -j${nproc}
 ################################################################################
 
 RUN echo "source /opt/ros/foxy/setup.bash" >> /root/.bashrc
-# RUN echo "source /home/ubuntu/ocr_ws/devel/setup.bash" >> /root/.bashrc
-RUN echo "/home/rachel_chan/ros2/foxy/faro/devel/setup.bash" >> /root/.bashrc
 
 RUN apt-get update && apt-get install -y \
     ros-foxy-cv-bridge \


### PR DESCRIPTION
This is a version of your dockerfile with the following changes:

* base image is nvidia/cuda dockerfile (note: I am not sure whether the base system needs cuda/nvidia-smi already installed)
* ROS2 is instead installed based on commands from osrf/ros2 foxy image
* some additional python packages such as torch/tesseract are installed
* `/usr/local/bin/python` is linked to python3, not python2

run as follows:
```
docker run -d --name nvidia_ros2 -v $HOME/ros2:/home/ros2/ -p 6080:80 --gpus all --shm-size 8G nvidia_ros2
```

`shm-size` parameter is important so that torch has enough memory to use the gpu properly.