### PR TITLE
Fix/gpg expire

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN ./tmp/deps/vnc.sh && \
 	rm -rf /var/lib/apt/lists/*
 
 RUN ln -s /usr/bin/python3 /usr/local/bin/python
-RUN ln -s /usr/bin/pip3 /usr/bin/pip
+RUN ln -sf /usr/bin/pip3 /usr/bin/pip
 
 ADD image /
 RUN pip install setuptools wheel && pip install -r /usr/lib/web/requirements.txt

--- a/deps/foxy.sh
+++ b/deps/foxy.sh
@@ -30,7 +30,7 @@ export LANG=en_US.UTF-8
 sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key  -o /usr/share/keyrings/ros-archive-keyring.gpg
 
 # setup sources.list
-sudo sh -c 'echo "deb [arch=$(dpkg --print-architecture)] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" > /etc/apt/sources.list.d/ros2-latest.list'
+sudo sh -c 'echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null'
 
 # install ros2 packages
 sudo apt-get update

--- a/deps/foxy.sh
+++ b/deps/foxy.sh
@@ -27,8 +27,7 @@ sudo update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
 export LANG=en_US.UTF-8
 
 # setup keys
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 \
-     --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key  -o /usr/share/keyrings/ros-archive-keyring.gpg
 
 # setup sources.list
 sudo sh -c 'echo "deb [arch=$(dpkg --print-architecture)] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" > /etc/apt/sources.list.d/ros2-latest.list'


### PR DESCRIPTION
#### What for?
the GPG key has expired and the installation way of ROS2 has changed.

#### Description

https://discourse.ros.org/t/ros-gpg-key-expiration-incident/20669